### PR TITLE
fix opensuse download link

### DIFF
--- a/download.html
+++ b/download.html
@@ -99,7 +99,7 @@ Some links may point to old versions of <abbr title="GNOME Commander">GCMD</abbr
 </td>
 <td>
 <ul class="imglist">
-<li><img src="img/opensuse.svg" width="32" height="32" alt=""><a href="https://software.opensuse.org/package/gnome-commander">Debian Linux</a></li>
+<li><img src="img/opensuse.svg" width="32" height="32" alt=""><a href="https://software.opensuse.org/package/gnome-commander">Opensuse</a></li>
 </ul>
 </td>
 </tr>


### PR DESCRIPTION
![Screenshot 2024-08-30 at 12-00-10 GNOME Commander - Download](https://github.com/user-attachments/assets/56a39e8c-3cf3-4401-989d-97db9181f547)

fix opensuse download link from "Debian Linux" to "Opensuse"